### PR TITLE
Add Python xpost: post to X via browser control (CDP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /target
+
+# Python
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -94,3 +94,15 @@ nix profile install github:andrewgazelka/post
 # With Cargo
 cargo install --git https://github.com/andrewgazelka/post
 ```
+
+
+## Python (browser control, no API keys)
+
+Prefer driving a browser you are already signed into instead of an OAuth app? See
+[`python/`](python/): a small `xpost` module that posts via the real X composer over
+the Chrome DevTools Protocol.
+
+```python
+import asyncio, xpost
+asyncio.run(xpost.post("hello world"))
+```

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,59 @@
+# xpost — post to X from Python via the browser
+
+A tiny Python module that posts to X (twitter) by driving a browser you are already
+signed into, over the Chrome DevTools Protocol (CDP). No API keys, no OAuth: it uses
+the real composer, exactly as you would by hand.
+
+This is the browser-control sibling of the Rust `post x` CLI in this repo (which uses
+the X API + OAuth 2.0). Use whichever fits: the CLI for headless/server posting with a
+developer app, this module when you just want to drive a logged-in window.
+
+## Use
+
+```python
+import asyncio, xpost
+
+asyncio.run(xpost.post("hello world"))            # compose + click Post
+asyncio.run(xpost.post("draft", confirm=False))   # stage only, do not send
+```
+
+Or from the shell:
+
+```bash
+python -m xpost "hello world"
+python -m xpost "draft" --dry-run        # stage without sending
+python -m xpost "hi" --endpoint http://127.0.0.1:9333
+```
+
+## Setup
+
+1. Launch a browser with remote debugging on (Chrome shown; any Chromium works):
+
+   ```bash
+   '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' \
+       --remote-debugging-port=9222 --user-data-dir=/tmp/x-profile
+   ```
+
+2. Sign into x.com in that window once.
+3. Run the examples above.
+
+## Notes
+
+- **Reply-style posts:** a message that starts with `@handle` is treated by X as a
+  reply-style mention and is filed under "Posts & replies", not the main timeline.
+  `xpost.is_reply_style(text)` reflects this.
+- **Clearing the composer** uses the OS-correct select-all chord (Cmd+A on macOS,
+  Ctrl+A elsewhere) and verifies the field is empty before typing, so a previous
+  draft can never bleed into a new post.
+- **Dia / Arc-engine browsers:** tabs created over CDP do not appear in their tab UI,
+  so this module never creates a tab; it reuses or navigates an existing one. Plain
+  Chrome shows everything normally.
+
+## Tests
+
+```bash
+cd python && python -m pytest
+```
+
+The unit tests cover the pure logic (select-all chord, reply detection). The
+browser-driving path is verified live against a real logged-in session.

--- a/python/test_xpost.py
+++ b/python/test_xpost.py
@@ -1,0 +1,42 @@
+"""Pure-logic tests for xpost (stdlib unittest, no browser, no third-party deps).
+
+The browser-driving paths are validated live (see README.md), but the bits that
+caused real bugs -- the OS-specific select-all chord and reply-style detection --
+are unit-tested here so they cannot regress.
+
+Run: ``python -m unittest`` (or ``python -m pytest`` if available).
+"""
+
+import inspect
+import unittest
+
+import xpost
+
+
+class SelectAllChordTests(unittest.TestCase):
+    def test_cmd_on_macos(self):
+        self.assertEqual(xpost.select_all_chord("darwin"), "Meta+a")
+
+    def test_ctrl_elsewhere(self):
+        self.assertEqual(xpost.select_all_chord("linux"), "Control+a")
+        self.assertEqual(xpost.select_all_chord("win32"), "Control+a")
+
+
+class ReplyStyleTests(unittest.TestCase):
+    def test_detects_leading_at(self):
+        self.assertTrue(xpost.is_reply_style("@diabrowser hello"))
+        self.assertTrue(xpost.is_reply_style("   @someone with leading space"))
+
+    def test_false_for_normal_post(self):
+        self.assertFalse(xpost.is_reply_style("hello @diabrowser in the middle"))
+        self.assertFalse(xpost.is_reply_style("just a normal post"))
+
+
+class ApiShapeTests(unittest.TestCase):
+    def test_post_and_compose_are_async(self):
+        self.assertTrue(inspect.iscoroutinefunction(xpost.post))
+        self.assertTrue(inspect.iscoroutinefunction(xpost.compose))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/xpost.py
+++ b/python/xpost.py
@@ -1,0 +1,152 @@
+"""Post to X (twitter) by driving a logged-in browser over the Chrome DevTools Protocol.
+
+No API keys: it attaches to a browser you are already signed into and uses the real
+composer, the same way you would by hand. This is the browser-control counterpart to
+the Rust `post x` CLI (which uses the X API + OAuth).
+
+    import asyncio, xpost
+    asyncio.run(xpost.post("hello world"))           # compose + click Post
+    asyncio.run(xpost.post("draft", confirm=False))  # stage only, do not send
+
+Start your browser with remote debugging first, e.g. Chrome:
+
+    '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome' \\
+        --remote-debugging-port=9222 --user-data-dir=/tmp/x-profile
+
+then sign into x.com in that window once.
+
+Note on Dia/Arc-engine browsers: tabs created over CDP do not appear in their tab UI,
+so this module never creates a tab; it reuses (or navigates) an existing one.
+"""
+
+from __future__ import annotations
+
+import json as _json
+import sys
+
+X_HOME = "https://x.com/home"
+DEFAULT_ENDPOINT = "http://127.0.0.1:9222"
+_COMPOSER = '[data-testid="tweetTextarea_0"]'
+_POST_BUTTON = '[data-testid="tweetButtonInline"], [data-testid="tweetButton"]'
+
+
+def select_all_chord(platform: str = sys.platform) -> str:
+    """The Playwright key chord that selects all text in a field, per OS.
+
+    macOS uses Cmd (``Meta``); everywhere else uses ``Control``. Getting this wrong
+    is why a naive clear leaves the previous draft in place and the new text is
+    appended to it.
+    """
+    return "Meta+a" if platform == "darwin" else "Control+a"
+
+
+def is_reply_style(text: str) -> bool:
+    """X treats a post that starts with ``@handle`` as a reply-style mention: it is
+    filed under "Posts & replies" rather than the main timeline."""
+    return text.lstrip().startswith("@")
+
+
+async def _connect(endpoint: str):
+    from playwright.async_api import async_playwright
+
+    pw = await async_playwright().start()
+    browser = await pw.chromium.connect_over_cdp(endpoint)
+    return pw, browser
+
+
+async def _x_page(browser):
+    """Reuse a logged-in x.com tab if present, else navigate an existing tab to x.com.
+
+    Never opens a new tab: Arc-engine browsers (Dia) do not render CDP-created tabs.
+    """
+    ctx = browser.contexts[0] if browser.contexts else await browser.new_context()
+    page = next((p for p in ctx.pages if "x.com" in p.url or "twitter.com" in p.url), None)
+    if page is None:
+        page = ctx.pages[-1] if ctx.pages else await ctx.new_page()
+        await page.goto(X_HOME, wait_until="domcontentloaded")
+    await page.bring_to_front()
+    return page
+
+
+async def _composer_text(page) -> str:
+    sel = _json.dumps(_COMPOSER)
+    text = await page.evaluate(
+        f"() => {{ const el = document.querySelector({sel}); return el ? el.innerText : null; }}"
+    )
+    # contenteditable reports a trailing newline; drop it so comparisons are exact.
+    return text[:-1] if text and text.endswith("\n") else text
+
+
+async def _clear(page) -> None:
+    """Fully empty the composer (OS-correct select-all, looped until verified empty)."""
+    chord = select_all_chord()
+    for _ in range(6):
+        await page.keyboard.press(chord)
+        await page.keyboard.press("Backspace")
+        await page.wait_for_timeout(120)
+        if not await _composer_text(page):
+            return
+    remaining = await _composer_text(page)
+    if remaining:
+        raise RuntimeError(f"could not clear composer; still has: {remaining!r}")
+
+
+async def compose(text: str, *, endpoint: str = DEFAULT_ENDPOINT, page=None):
+    """Open the composer, clear it, type ``text``, and verify the field matches. No send."""
+    own = page is None
+    if own:
+        _pw, browser = await _connect(endpoint)
+        page = await _x_page(browser)
+    if "/home" not in page.url and "/compose" not in page.url:
+        await page.goto(X_HOME, wait_until="domcontentloaded")
+        await page.wait_for_timeout(800)
+    box = page.locator(_COMPOSER)
+    await box.click()
+    await _clear(page)
+    await page.keyboard.type(text, delay=12)
+    await page.wait_for_timeout(400)
+    got = await _composer_text(page)
+    if got != text:
+        raise RuntimeError(f"composer mismatch.\n wanted: {text!r}\n got:    {got!r}")
+    return page
+
+
+async def post(text: str, *, endpoint: str = DEFAULT_ENDPOINT, confirm: bool = True) -> dict:
+    """Compose ``text`` and click Post. ``confirm=False`` stages it without sending.
+
+    Returns a small dict describing what happened. Raises if the field cannot be
+    cleared/typed or if X disables the Post button (empty or over the length limit).
+    """
+    page = await compose(text, endpoint=endpoint)
+    if not confirm:
+        return {"sent": False, "staged": text, "reply_style": is_reply_style(text)}
+    button = page.locator(_POST_BUTTON).first
+    if await button.is_disabled():
+        raise RuntimeError("X disabled the Post button (empty or over length); not sending")
+    await button.click()
+    await page.wait_for_timeout(2500)
+    after = await _composer_text(page)
+    return {
+        "sent": not after,
+        "text": text,
+        "reply_style": is_reply_style(text),
+        "composer_after": after,
+    }
+
+
+def _main(argv: list[str]) -> int:
+    import argparse
+    import asyncio
+
+    parser = argparse.ArgumentParser(prog="xpost", description="Post to X via a logged-in browser (CDP).")
+    parser.add_argument("text", help="the message to post")
+    parser.add_argument("--endpoint", default=DEFAULT_ENDPOINT, help="CDP endpoint (default %(default)s)")
+    parser.add_argument("--dry-run", action="store_true", help="stage in the composer without sending")
+    args = parser.parse_args(argv)
+    result = asyncio.run(post(args.text, endpoint=args.endpoint, confirm=not args.dry_run))
+    print(result)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv[1:]))


### PR DESCRIPTION
Adds a Python way to post to X by driving a logged-in browser over CDP — no API keys, the browser-control sibling of the Rust `post x` OAuth CLI.

**What**
- `python/xpost.py`: async `post()` / `compose()` and a `python -m xpost "..."` CLI
- OS-correct composer clear (Cmd+A on macOS, Ctrl+A elsewhere), verified empty before typing so a previous draft can't bleed into a new post
- reply-style awareness: a leading `@handle` is filed under Posts & replies
- never creates a tab (Arc-engine browsers like Dia hide CDP-created tabs); reuses or navigates an existing one
- `python/test_xpost.py`: stdlib `unittest` for the pure logic

**Tested**
- `python -m unittest` → 5 passing, no warnings (`-W error::SyntaxWarning`)
- Live e2e: composed + sent a real post from `@andrewgazelka`, and dry-run staged from the committed module against a logged-in session
